### PR TITLE
Fix active space truncation

### DIFF
--- a/framework/active_space_truncation/step1_orbitals.py
+++ b/framework/active_space_truncation/step1_orbitals.py
@@ -159,8 +159,8 @@ def run_orbital_analysis(
 
     diag.proposed_active_indices = candidates
     diag.proposed_n_active_orbitals = len(candidates)
-    n_active_e = mol.nelectron - 2 * n_core
-    diag.proposed_n_active_electrons = min(n_active_e, 2 * len(candidates))
+    n_active_occupied = len([i for i in candidates if i < n_occ])
+    diag.proposed_n_active_electrons = 2 * n_active_occupied
 
     # Optional basis comparison
     if run_basis_comparison:

--- a/framework/active_space_truncation/step2_active_space.py
+++ b/framework/active_space_truncation/step2_active_space.py
@@ -74,7 +74,10 @@ def validate_active_space(
         mf.kernel()
 
     mc = mcscf.CASCI(mf, ncas, nelecas)
-    mc.kernel()
+    # PySCF sort_mo uses 1-based orbital indices
+    cas_list = [i + 1 for i in diagnostics.proposed_active_indices]
+    mo = mcscf.sort_mo(mc, mf.mo_coeff, cas_list)
+    mc.kernel(mo)
 
     result.casci_energy = float(mc.e_tot)
     result.casci_converged = True
@@ -86,7 +89,8 @@ def validate_active_space(
 
     if run_casscf:
         mc_scf = mcscf.CASSCF(mf, ncas, nelecas)
-        mc_scf.kernel()
+        mo_scf = mcscf.sort_mo(mc_scf, mf.mo_coeff, cas_list)
+        mc_scf.kernel(mo_scf)
         result.casscf_energy = float(mc_scf.e_tot)
         result.casscf_converged = bool(mc_scf.converged)
 

--- a/framework/active_space_truncation/step3_hamiltonian.py
+++ b/framework/active_space_truncation/step3_hamiltonian.py
@@ -73,8 +73,9 @@ def build_qubit_hamiltonian(
 
     mol_data = run_pyscf(mol_data, run_scf=True, run_mp2=True, run_fci=False)
 
-    occupied_indices = diagnostics.core_orbital_indices
-    active_indices = diagnostics.proposed_active_indices
+    n_occ = geometry.n_electrons // 2
+    active_indices = list(diagnostics.proposed_active_indices)
+    occupied_indices = [i for i in range(n_occ) if i not in active_indices]
 
     molecular_hamiltonian = mol_data.get_molecular_hamiltonian(
         occupied_indices=occupied_indices,


### PR DESCRIPTION
Noticed that CASCI and Hamiltonian used different orbitals, causing ~101 Ha mismatch in reference energy. This PR makes both use the MP2-selected orbitals → mismatch gone and meaningful correlation:

1.  Fixed active electron count to reflect which proposed orbitals are actually HF-occupied, rather than naively capping total valence electrons. This corrects the (nelec, norb) specification when the active set includes virtual orbitals (e.g. (8e, 6o) instead of the incorrect (12e, 6o) for glycine).
2. CASCI now uses sort_mo to target the MP2-proposed active orbitals instead of PySCF's default consecutive HOMO block. This ensures CASCI validates the same orbitals that the qubit Hamiltonian is built from.
3. The qubit Hamiltonian now uses proposed_active_indices directly (with all other occupied orbitals frozen), instead of deriving a consecutive block from ncore.