### PR TITLE
Updated iQCC and framework README

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -69,7 +69,7 @@ framework/
 │   ├── vqe_qubit_adapt.py         # Qubit-ADAPT-VQE
 │   ├── vqe_hardware_efficient.py  # Hardware-efficient layered ansatz
 │   ├── vqe_qaoa_inspired.py       # QAOA-inspired VQE
-│   ├── vqe_iqcc.py                # iQCC (iterative qubit coupled clustering)
+│   ├── vqe_iqcc.py                # iQCC (iterative qubit coupled clustering) with truncated approximation of canonical transform
 │   ├── vqe_iqcc_inspired.py       # iQCC-inspired ADAPT variant
 │   ├── vqe_CB.py                  # Classically boosted VQE
 │   ├── vqe_hva.py                 # Hamiltonian variational ansatz

--- a/framework/algorithms/vqe_iqcc_true.py
+++ b/framework/algorithms/vqe_iqcc_true.py
@@ -30,6 +30,7 @@ class iQCC_true_VQE(BaseVQE):
                  hamiltonian: QubitHamiltonian, 
                  max_operators: int=20, 
                  gradient_threshold: float= 1e-4,
+                 bound: float=0.005,
                  **kwargs):
         super().__init__(hamiltonian, kwargs)
         self.name = 'iqcc_vqe'
@@ -37,6 +38,7 @@ class iQCC_true_VQE(BaseVQE):
         self.max_operators = max_operators
         self.gradient_threshold = gradient_threshold
         self.max_terms = 10000
+        self.bound = bound
 
         n_el_raw = self.hamiltonian.molecule.n_electrons or self.n_qubits // 2
         if n_el_raw >= self.n_qubits:
@@ -151,7 +153,7 @@ class iQCC_true_VQE(BaseVQE):
                 H_trial_pl = of_to_pennylane(H_trial)
                 return self.compute_hf_energy(H_trial_pl)
 
-            res = minimize_scalar(energy_tau, bounds=(-0.005,0.005), method='bounded')
+            res = minimize_scalar(energy_tau, bounds=(-1 * self.bound,self.bound), method='bounded')
             tau_opt = res.x
 
             comm1 = of_commutator(H_current, best_op_of)


### PR DESCRIPTION
iQCC bound now variable rather than hard-coded. Also updated README, explaining iQCC uses truncated approximation of canonical transformation for superior ease of computation